### PR TITLE
feature: password checked during connection

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -11,6 +11,7 @@ class Client
 		std::string _IP;
 		pollfd		_socket;
 		bool 		_isOperator;
+		bool		_isRegistered;
 		std::vector<std::string> _channels;
 
 		
@@ -33,11 +34,13 @@ class Client
 		void 			setUsername(std::string &username);
 		void 			setHostname(std::string &hostname);
 		void 			setOperator(bool isOperator);
+		void			setRegistered(bool status);
 		
 		std::string 	username(void) const;
 		std::string 	nickname(void) const;
 		std::string 	hostname(void) const;
         bool    		isOperator(void) const;
+		bool			isRegistered(void) const;
 		
 		/* member functions */
 		void    		joinChannel(std::string channelName);

--- a/include/MsgHandler.hpp
+++ b/include/MsgHandler.hpp
@@ -27,6 +27,7 @@ class MsgHandler
 		void handleKICK(std::string &username, std::string &channelName, Client &client);
 		void handleMODE(std::string &channelName, std::string &mode, Client &client);
 		void handleTOPIC(std::string &channelName, std::string &topic, Client &client);
+		void handlePASS(std::string &password, Client &client);
 
 		void handleOPER(std::string &nickname, std::string &password, Client &client);
 };

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -31,9 +31,11 @@ class Server
 		void 			handleNewConnectionRequest();
 		void 			disconnectClient(Client &client);
 		void 			addclient(pollfd &clientSocket);
+		bool			validatePassword(std::string &password);
 		std::string 	name();
 		
 		std::map<std::string,std::string> getOpers();
+		std::string	getPassword();
 
 		//std::vector<std::string> ftSplit(const std::string& input , char delim);
 		//std::vector<std::string> splitByString(const std::string& input, const std::string& delim);

--- a/include/irc.hpp
+++ b/include/irc.hpp
@@ -55,7 +55,7 @@
 # define ERR_PORT "Invalid port number"
 # define ERR_PORT_NUMERIC "Port number must be numeric (1024 - 65535)"
 # define ERR_INVALID_PASSWORD "Invalid password"
-# define ERR_INVALID_PASSWORD_LENGTH "Password must be 1 characters long"
+# define ERR_PASSWORD_FORMAT "Password must be between 4-6 characters long"
 
 // Reply codes for server responses
 #define RPL_WELCOME "001"
@@ -82,6 +82,7 @@ int             isDigits(const std::string& s);
 int             isValidPort(const std::string& s);
 unsigned int    getUnsignedInt(const std::string& prompt);
 void            printStr(const std::string& text, const std::string& colour);
+int             isValidPassword(const std::string& pwd);
 
 // Logging
 void info(const std::string& message);

--- a/sources/Client.cpp
+++ b/sources/Client.cpp
@@ -8,6 +8,7 @@ Client::Client()
 	_nickname = "default";
 	_username = "default";
 	_isOperator = false;
+	_isRegistered = false;
 }
 
 Client::Client(pollfd &clientSocket)
@@ -16,6 +17,7 @@ Client::Client(pollfd &clientSocket)
 	_username = "default";
 	_socket = clientSocket;
 	_isOperator = false;
+	_isRegistered = false;
 }
 
 Client::~Client() {}
@@ -74,30 +76,45 @@ void Client::setIP(std::string IP)
 	_IP = IP;
 }
 
-bool Client::isOperator() const {
-	return _isOperator;
-}
-
 void Client::setOperator(bool isOperator) {
 	_isOperator = isOperator;
 }
 
-std::vector<std::string> Client::getChannels() const {
-	return (_channels);
-}
 void 	Client::setOper(bool status)
 {
 	_isOperator = status;
 }
 
+void Client::setRegistered(bool status)
+{
+	_isRegistered = status;
+}
+
+bool Client::isOperator() const
+{
+	return (_isOperator);
+}
+
+bool Client::isRegistered() const
+{
+	return (_isRegistered);
+}
+
+std::vector<std::string> Client::getChannels() const
+{
+	return (_channels);
+}
+
 // ************************************************************************** //
 //                             Public Functions                               //
 // ************************************************************************** //
-void Client::joinChannel(std::string channelName) {
+void Client::joinChannel(std::string channelName)
+{
 	_channels.push_back(channelName);
 }
 
-void Client::leaveChannel(std::string channelName) {
+void Client::leaveChannel(std::string channelName)
+{
 	std::vector<std::string>::iterator it = std::find(_channels.begin(), _channels.end(), channelName);
 	if (it != _channels.end()) {
 		_channels.erase(it);

--- a/sources/MsgHandler.cpp
+++ b/sources/MsgHandler.cpp
@@ -99,6 +99,20 @@ void MsgHandler::handleOPER(std::string &nickname, std::string &password, Client
 	}
 }
 
+void	MsgHandler::handlePASS(std::string &password, Client &client)
+{
+	if (password == _server.getPassword())
+	{
+		client.setRegistered(true);
+		send(client.getFd(), "Client authenticated with the mserver\r\n", 23, MSG_DONTWAIT);
+	}
+	else
+	{
+		send(client.getFd(), "Invalid password\r\n", 18, MSG_DONTWAIT);
+		_server.disconnectClient(client);
+	}
+}
+
 void MsgHandler::respond(std::string &msg, Client &client)
 {
 	std::vector<std::string> msgData = split(msg, ' ');
@@ -126,6 +140,8 @@ void MsgHandler::respond(std::string &msg, Client &client)
 		//add to channel ...
 	else if (msgData[0] == "OPER")
 		handleOPER(msgData[1], msgData[2], client);
+	else if (msgData[0] == "PASS")
+		handlePASS(msgData[1], client);
 }
 
 void MsgHandler::receiveMessage(Client &client)

--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -69,6 +69,11 @@ std::string Server::name()
 	return (_serverName);
 }
 
+std::string Server::getPassword()
+{
+	return (_password);
+}
+
 void Server::addclient(pollfd &clientSocket)
 {
 	Client *newClient = new Client(clientSocket);
@@ -92,7 +97,6 @@ void Server::handleNewConnectionRequest()
 	}
 
 	info("New connection request received");
-	//if (validatePassword())
 	send(clientSocket.fd, "CAP * LS : \r\n", 13, 0);
 	addclient(clientSocket);
   	info("New client connected with fd: " + intToString(clientSocket.fd));

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -7,8 +7,8 @@ int    checkInput(int ac, char **av) {
     if (!isValidPort(av[1])) {
         return(errMsg("", ERR_PORT_NUMERIC, 1));
     }
-    if (strlen(av[2]) != 1) {
-        return(errMsg("", ERR_INVALID_PASSWORD_LENGTH, 1));
+    if (!isValidPassword(av[2])) {
+        return(errMsg("", ERR_PASSWORD_FORMAT, 1));
     }
     // ...
     return 0;

--- a/sources/utils/Utils.cpp
+++ b/sources/utils/Utils.cpp
@@ -86,3 +86,13 @@ std::vector<std::string> split(const std::string& str, char delimiter)
 
     return result;
 }
+
+int isValidPassword(const std::string& pwd)
+{
+    for (std::string::const_iterator it = pwd.begin(); it != pwd.end(); ++it)
+    {
+        if (!std::isprint(*it))
+            return (0);
+    }
+    return (pwd.length() >= 4 && pwd.length() <= 6);
+}


### PR DESCRIPTION
This pull request introduces several changes to the `Client`, `MsgHandler`, and `Server` classes, as well as updates to password validation logic. The primary focus is on adding functionality for client registration and password handling.

### Client Class Enhancements:
* Added `_isRegistered` member variable and corresponding getter and setter methods to the `Client` class in `include/Client.hpp` and `sources/Client.cpp`. [[1]](diffhunk://#diff-e51bf9f83fe8e45333b20bd892f51a986ad580840527fc25cb55224675ed95eeR14) [[2]](diffhunk://#diff-e51bf9f83fe8e45333b20bd892f51a986ad580840527fc25cb55224675ed95eeR37-R43) [[3]](diffhunk://#diff-e5593f2a08518d9c40462f2c4f0bf15c2bcf576da98b31e44ea685a0688a3333R11) [[4]](diffhunk://#diff-e5593f2a08518d9c40462f2c4f0bf15c2bcf576da98b31e44ea685a0688a3333R20) [[5]](diffhunk://#diff-e5593f2a08518d9c40462f2c4f0bf15c2bcf576da98b31e44ea685a0688a3333L77-R117)

### MsgHandler Class Enhancements:
* Added `handlePASS` method to the `MsgHandler` class in `include/MsgHandler.hpp` and `sources/MsgHandler.cpp` to handle client password authentication. [[1]](diffhunk://#diff-572f78e01b32675ec6ee24f96520216fa4faec83ba0b0325b499db015383b119R30) [[2]](diffhunk://#diff-50545e1ac29d074e36e771f0f6daab93f2614e5d49031a0bebb894812f8452c8R102-R115) [[3]](diffhunk://#diff-50545e1ac29d074e36e771f0f6daab93f2614e5d49031a0bebb894812f8452c8R143-R144)

### Server Class Enhancements:
* Added `validatePassword` and `getPassword` methods to the `Server` class in `include/Server.hpp` and `sources/Server.cpp` to support password validation. [[1]](diffhunk://#diff-47d4f87e3902e8a805974de3fc31376442eeb30f4b1191e42f8e11602e385562R34-R38) [[2]](diffhunk://#diff-adfbded07e2d83ee27c4efde8ca3004ae1e3904227decf02f7f448b2c69650c1R72-R76)

### Password Validation Logic:
* Updated password validation logic to ensure passwords are between 4-6 characters long and contain printable characters. Changes made in `include/irc.hpp`, `sources/main.cpp`, and `sources/utils/Utils.cpp`. [[1]](diffhunk://#diff-2df902fb3a5acd129eafd0ef8786379c3e9d9b7319dc97160461a656aa15efb3L58-R58) [[2]](diffhunk://#diff-2df902fb3a5acd129eafd0ef8786379c3e9d9b7319dc97160461a656aa15efb3R85) [[3]](diffhunk://#diff-669fd9ef8dce5419b9db6f6be17c28372a26dc6103efe3c4be14f912204c3a7aL10-R11) [[4]](diffhunk://#diff-a8f46adf20b2339f14cb9df36c8245e386b494917d2c01cac9f9d19ff69876b3R89-R98)